### PR TITLE
File#content enhancements

### DIFF
--- a/lib/studio_api/file.rb
+++ b/lib/studio_api/file.rb
@@ -2,15 +2,15 @@ require "studio_api/studio_resource"
 require "cgi"
 module StudioApi
   # Represents overlay files which can be loaded to appliance.
-  # 
+  #
   # Supports finding files for appliance, updating metadata, deleting, uploading and downloading.
-  # 
+  #
   # @example Find files for appliance
   # StudioApi::File.find :all, :params => { :appliance_id => 1234 }
   #
   # @example Upload file Xorg.conf
   #   File.open ("/tmp/xorg.conf") do |file|
-  #     StudioApi::File.upload file, 1234, :path => "/etc/X11", 
+  #     StudioApi::File.upload file, 1234, :path => "/etc/X11",
   #                         :filename => "Xorg.conf", :permissions => "0755",
   #                         :owner => "root"
   #   end
@@ -28,9 +28,13 @@ module StudioApi
 
     # Downloads file to output. Allow downloading to stream or to path.
     # @return [String] content of file
-    def content
+    # @yield [tempfile] Access the tempfile from the block parameter
+    # @yieldparam[tempfile Tempfile] Tempfile instance
+    # @yieldreturn [nil] Tempfile gets closed when the block returns
+    def content &block
       rq = GenericRequest.new self.class.studio_connection
-      rq.get "/files/#{id.to_i}/data"
+      path = "/files/#{id.to_i}/data"
+      block_given? ? rq.get_file(path, &block) : rq.get(path)
     end
 
     # Overwritte file content and keep metadata ( of course without such things like size )
@@ -45,7 +49,7 @@ module StudioApi
     end
 
     # Uploads file to appliance
-    # @param (String,File) content as String or as opened File 
+    # @param (String,File) content as String or as opened File
     #   ( in this case its name is used as default for uploaded file name)
     # @param (#to_i) appliance_id id of appliance where to upload
     # @param (Hash<#to_s,#to_s>) options optional parameters, see API documentation
@@ -64,7 +68,7 @@ module StudioApi
       end
     end
 
-private 
+private
     # file uses for update parameter put
     # @private
     def new?

--- a/lib/studio_api/file.rb
+++ b/lib/studio_api/file.rb
@@ -27,10 +27,11 @@ module StudioApi
     self.element_name = "file"
 
     # Downloads file to output. Allow downloading to stream or to path.
-    # @return [String] content of file
-    # @yield [tempfile] Access the tempfile from the block parameter
-    # @yieldparam[tempfile Tempfile] Tempfile instance
-    # @yieldreturn [nil] Tempfile gets closed when the block returns
+    # @return [String] content of file if no block
+    # @return [nil] if block given
+    # @yield [socket response segment] Read the Net::HTTPResponse segments
+    # @yieldparam[body segment] buffered chunk of body
+    # @yieldreturn [nil]
     def content &block
       rq = GenericRequest.new self.class.studio_connection
       path = "/files/#{id.to_i}/data"

--- a/lib/studio_api/generic_request.rb
+++ b/lib/studio_api/generic_request.rb
@@ -26,7 +26,6 @@ require 'active_support'
 require 'active_resource/formats'
 require 'active_resource/connection'
 require 'tempfile' unless defined? Tempfile
-require 'securerandom'
 
 require 'studio_api/util'
 
@@ -121,7 +120,7 @@ module StudioApi
     def do_tempfile_request request, &block
       request.basic_auth @connection.user, @connection.password
       @http.start do |http|
-        Tempfile.open SecureRandom.hex(10) do |tmp|
+        Tempfile.open '' do |tmp|
           http.request request do |response|
             handle_active_resource_exception response
             response.read_body {|body| tmp.write body }

--- a/lib/studio_api/generic_request.rb
+++ b/lib/studio_api/generic_request.rb
@@ -25,6 +25,8 @@ require 'net/https'
 require 'active_support'
 require 'active_resource/formats'
 require 'active_resource/connection'
+require 'tempfile' unless defined? Tempfile
+require 'securerandom'
 
 require 'studio_api/util'
 
@@ -66,6 +68,15 @@ module StudioApi
       do_request(Net::HTTP::Get.new(Util.join_relative_url(@connection.uri.request_uri,path)))
     end
 
+    # sends get request to suse studio
+    # @return (nil) as response
+    # @raise [ActiveResource::ConnectionError] when problem occur during connection
+    def get_file(path, &block)
+      do_tempfile_request(Net::HTTP::Get.new(
+        Util.join_relative_url(@connection.uri.request_uri,path)),
+        &block)
+    end
+
     # sends delete request
     # @param (String) path relative path from api root
     # @return (String) response body from studio
@@ -102,18 +113,31 @@ module StudioApi
       request.basic_auth @connection.user, @connection.password
       @http.start() do
         response = @http.request request
-        unless response.kind_of? Net::HTTPSuccess
-          msg = error_message response
-          create_active_resource_exception response,msg
-        end
+        handle_active_resource_exception response
         response.body
       end
     end
 
+    def do_tempfile_request request, &block
+      request.basic_auth @connection.user, @connection.password
+      @http.start do |http|
+        Tempfile.open SecureRandom.hex(10) do |tmp|
+          http.request request do |response|
+            handle_active_resource_exception response
+            response.read_body {|body| tmp.write body }
+          end
+          yield tmp
+        end
+      end
+    end
+
       #XXX not so nice to use internal method, but better to be DRY and proper test if it works with supported rails
-    def create_active_resource_exception response,msg
-      response.instance_variable_set "@message",msg
-      ActiveResource::Connection.new('').send :handle_response, response
+    def handle_active_resource_exception response
+      unless response.kind_of? Net::HTTPSuccess
+        msg = error_message response
+        response.instance_variable_set "@message",msg
+        ActiveResource::Connection.new('').send :handle_response, response
+      end
     end
 
     def error_message response

--- a/lib/studio_api/rpm.rb
+++ b/lib/studio_api/rpm.rb
@@ -3,9 +3,9 @@ require 'cgi'
 
 module StudioApi
   # Represents Additional rpms which can user upload to studio.
-  # 
+  #
   # Allows uploading, downloading, listing (via find) and deleting
-  # 
+  #
   # @example Delete own rpm
   #   rpms = StudioApi::Rpm.find :all, :params => { :base_system => "SLE11" }
   #   my_pac = rpms.find {|r| r.filename =~ /my_pac/ }
@@ -30,8 +30,10 @@ module StudioApi
 
     # Downloads file to specified path.
     # @return [String] content of rpm
-    def content
-      GenericRequest.new(self.class.studio_connection).get "/rpms/#{id.to_i}/data"
+    def content &block
+      request = GenericRequest.new self.class.studio_connection
+      path = "/rpms/#{id.to_i}/data"
+      block_given? ? request.get_file(path, &block) : request.get(path)
     end
   end
 end

--- a/lib/studio_api/rpm.rb
+++ b/lib/studio_api/rpm.rb
@@ -30,6 +30,9 @@ module StudioApi
 
     # Downloads file to specified path.
     # @return [String] content of rpm
+    # @yield [tempfile] Access the tempfile from the block parameter
+    # @yieldparam[tempfile Tempfile] Tempfile instance
+    # @yieldreturn [nil] Tempfile gets closed when the block returns
     def content &block
       request = GenericRequest.new self.class.studio_connection
       path = "/rpms/#{id.to_i}/data"

--- a/test/file_test.rb
+++ b/test/file_test.rb
@@ -51,14 +51,15 @@ class File1Test < Test::Unit::TestCase
     file_path = File.join File.dirname(__FILE__), 'responses'
     register_fake_response_from_file :get, "/api/files/#{@file_id}/data", file_name
     register_fake_response_from_file :get, "/api/files/#{@file_id}", file_name
-    f = StudioApi::File.find(@file_id)
+    studio_file = StudioApi::File.find(@file_id)
+    response = StringIO.new
     File.open(File.join(file_path, file_name), 'r') do |file|
-      assert_equal f.content, file.read
-      f.content do |tmp|
-        tmp.rewind
-        file.rewind
-        assert_equal tmp.read, file.read
+      assert_equal studio_file.content, file.read
+      studio_file.content do |body|
+        response << body
       end
+      file.rewind
+      assert_equal file.read, response.string
     end
   end
 end

--- a/test/file_test.rb
+++ b/test/file_test.rb
@@ -36,14 +36,14 @@ class File1Test < Test::Unit::TestCase
   end
 
   def test_update
-   register_fake_response_from_file :get, "/api/files/#{@file_id}",
-                                    'file.xml'
-   register_fake_response_from_file :put, "/api/files/#{@file_id}",
-                                    'file.xml'
+    register_fake_response_from_file :get, "/api/files/#{@file_id}",
+                                     'file.xml'
+    register_fake_response_from_file :put, "/api/files/#{@file_id}",
+                                     'file.xml'
 
-   f = StudioApi::File.find(@file_id)
-   f.path = "/tmp"
-   assert f.save
+    f = StudioApi::File.find(@file_id)
+    f.path = "/tmp"
+    assert f.save
   end
 end
 

--- a/test/file_test.rb
+++ b/test/file_test.rb
@@ -45,5 +45,21 @@ class File1Test < Test::Unit::TestCase
     f.path = "/tmp"
     assert f.save
   end
+
+  def test_content
+    file_name = 'file.xml'
+    file_path = File.join File.dirname(__FILE__), 'responses'
+    register_fake_response_from_file :get, "/api/files/#{@file_id}/data", file_name
+    register_fake_response_from_file :get, "/api/files/#{@file_id}", file_name
+    f = StudioApi::File.find(@file_id)
+    File.open(File.join(file_path, file_name), 'r') do |file|
+      assert_equal f.content, file.read
+      f.content do |tmp|
+        tmp.rewind
+        file.rewind
+        assert_equal tmp.read, file.read
+      end
+    end
+  end
 end
 

--- a/test/rpm_test.rb
+++ b/test/rpm_test.rb
@@ -53,8 +53,12 @@ class RpmTest < Test::Unit::TestCase
    def test_download_with_block
      register_fake_response :get, "/api/rpms/#{@rpm_id}/data", @rpm_data
      file_content = nil
-     rpm = StudioApi::Rpm.new(:id=> @rpm_id).content {|f| f.rewind; file_content = f.read }
-     assert_equal @rpm_data, file_content
+     rpm = StudioApi::Rpm.new(:id=> @rpm_id)
+     response = StringIO.new
+     rpm.content do |body|
+       response << body
+     end
+     assert_equal @rpm_data, response.string
    end
 
 

--- a/test/rpm_test.rb
+++ b/test/rpm_test.rb
@@ -51,7 +51,7 @@ class RpmTest < Test::Unit::TestCase
    end
 
    def test_download_with_block
-     fake_req = register_fake_response :get, "/api/rpms/#{@rpm_id}/data", @rpm_data
+     register_fake_response :get, "/api/rpms/#{@rpm_id}/data", @rpm_data
      file_content = nil
      rpm = StudioApi::Rpm.new(:id=> @rpm_id).content {|f| f.rewind; file_content = f.read }
      assert_equal @rpm_data, file_content

--- a/test/rpm_test.rb
+++ b/test/rpm_test.rb
@@ -50,4 +50,12 @@ class RpmTest < Test::Unit::TestCase
      assert StudioApi::Rpm.upload(@rpm_data, "SLE11")
    end
 
+   def test_download_with_block
+     fake_req = register_fake_response :get, "/api/rpms/#{@rpm_id}/data", @rpm_data
+     file_content = nil
+     rpm = StudioApi::Rpm.new(:id=> @rpm_id).content {|f| f.rewind; file_content = f.read }
+     assert_equal @rpm_data, file_content
+   end
+
+
 end


### PR DESCRIPTION
## Edit:

To avoid the use of Tempfile and better data stream handling now we can access the chunked body of the response directly from within the block parameter (thanks to jreidinger for the hint):

``` ruby
# setup the StudioApi::Connection
remote_file = StudioApi::File.find 123
remote_file.content do |response|
  # write the chunked response somwhere
  File.open('some_file','w') {|f| f.write response }
end
```

The same is valid for the Rpm#content method. Test for both classes added.
## Orig

I added a block to the #content method to preserve the current functionality (returning the http response directly) and to avoid loading the files into memory. When the block is used the file is being saved as a Tempfile first and then it is to be accessed from the block parameter for further manipulation.
## Example:

``` ruby
# setup the StudioApi::Connection
# find the file
remote_file = StudioApi::File.find 123
destination = '/home/user/new_file'

remote_file.content do |temp_file|
  # do something with the temp_file
  File.copy temp_file.path, destination
end
# the Tempfile is deleted at the end of the block
```
## Other:
- missing tests: the Fakeweb gem is a beast for testing the functionality of that method, some hint please so I could make some testing here
