### PR TITLE
Inspect connection before resource call

### DIFF
--- a/lib/studio_api/studio_resource.rb
+++ b/lib/studio_api/studio_resource.rb
@@ -4,11 +4,11 @@ require "studio_api/util"
 require "studio_api/studio_resource"
 
 module StudioApi
-  # Adds ability to ActiveResource::Base (short as ARes) to easy set connection to studio in 
+  # Adds ability to ActiveResource::Base (short as ARes) to easy set connection to studio in
   # dynamic way, which is not so easy as ARes is designed for static values.
   # Also modify a few expectation of ActiveResource to fit studio API ( like
   # missing xml suffix in calls ).
-  # 
+  #
   # @example Add new Studio Resource
   #   # enclose it in module allows to automatic settings with Util
   #   module StudioApi
@@ -62,6 +62,7 @@ module StudioApi
     # We need to overwrite the paths methods because susestudio doesn't use the
     # standard .xml filename extension which is expected by ActiveResource.
     def element_path(id, prefix_options = {}, query_options = nil)
+      inspect_connection
       prefix_options, query_options = split_options(prefix_options) if query_options.nil?
       "#{prefix(prefix_options)}#{collection_name}/#{id}#{query_string(query_options)}"
     end
@@ -69,8 +70,18 @@ module StudioApi
     # We need to overwrite the paths methods because susestudio doesn't use the
     # standard .xml filename extension which is expected by ActiveResource.
     def collection_path(prefix_options = {}, query_options = nil)
+      inspect_connection
       prefix_options, query_options = split_options(prefix_options) if query_options.nil?
       "#{prefix(prefix_options)}#{collection_name}#{query_string(query_options)}"
+    end
+
+    private
+
+    def inspect_connection
+      unless @studio_connection
+        raise RuntimeError, 'Connection to Studio is not set
+        Try: StudioApi::Util.studio_connection = StudioApi::Connection.new username, api_key, api_uri'
+      end
     end
   end
 end

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -39,3 +39,22 @@ class ResourceTest < Test::Unit::TestCase
   end
 
 end
+
+class NoConnectionTest < Test::Unit::TestCase
+  def test_find
+    assert_raise RuntimeError do
+      MyTest.find rand 1000
+    end
+
+    assert_raise RuntimeError do
+      MyTest2.find rand 100
+    end
+  end
+
+  def test_message
+    MyTest.find rand 100
+  rescue RuntimeError => e
+    assert_match /Connection to Studio is not set/, e.message
+  end
+
+end


### PR DESCRIPTION
Now if no connection is defined we get:

``` ruby
StudioApi::Appliance.find 12345
NoMethodError: undefined method `path' for nil:NilClass
    from /home/vmoravec/.rvm/gems/ruby-1.8.7-p352/gems/activeresource-3.2.1/lib/active_resource/base.rb:588:in `prefix'
    from /home/vmoravec/.rvm/gems/ruby-1.8.7-p352/gems/studio_api-3.2.0/lib/studio_api/studio_resource.rb:73:in `collection_path'
    from /home/vmoravec/.rvm/gems/ruby-1.8.7-p352/gems/activeresource-3.2.1/lib/active_resource/base.rb:901:in `find_every'
    from /home/vmoravec/.rvm/gems/ruby-1.8.7-p352/gems/activeresource-3.2.1/lib/active_resource/base.rb:814:in `find'
    from (irb):4
```

With this patch:

``` ruby
StudioApi::Appliance.find 12345
RuntimeError: Connection to Studio is not set
        Try: StudioApi::Util.studio_connection = StudioApi::Connection.new username, api_key, api_uri
    from ./studio_api/studio_resource.rb:82:in `inspect_connection'
    from ./studio_api/studio_resource.rb:73:in `collection_path'
    from /home/vmoravec/.rvm/gems/ruby-1.8.7-p352/gems/activeresource-3.2.1/lib/active_resource/base.rb:901:in `find_every'
    from /home/vmoravec/.rvm/gems/ruby-1.8.7-p352/gems/activeresource-3.2.1/lib/active_resource/base.rb:814:in `find'
    from (irb):2
```

Tests included.
